### PR TITLE
Remove `Update(entity)` from `UpdateAsync()`

### DIFF
--- a/src/Supermarket.API/Services/CategoryService.cs
+++ b/src/Supermarket.API/Services/CategoryService.cs
@@ -62,7 +62,6 @@ namespace Supermarket.API.Services
 
             try
             {
-                _categoryRepository.Update(existingCategory);
                 await _unitOfWork.CompleteAsync();
 
                 return new CategoryResponse(existingCategory);


### PR DESCRIPTION
If I am not mistaken, the `Update()` method only tells EF to track the entity.
Because we already have the entity from the context (`FindByIdAsync()`) and then apply the changes to it, we can safely remove that line.